### PR TITLE
Add a property to control the Metallic Specular of generated materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,30 @@ A plugin that allows you to laod GoldSrc BSP files into Godot
 
 ## Video Demo
 [![](https://i.imgur.com/UbihCVB.png)](https://www.youtube.com/watch?v=-gloaTbZxmU)
- 
+
 ## Installation
-Copy the "addons" folder into the root directory of the Godot Project  
- 
-Go to Project->Project Settings->Plugins and set the plugins status to "Active"  
-  
-## Usage  
+Copy the "addons" folder into the root directory of the Godot Project
+
+Go to Project->Project Settings->Plugins and set the plugins status to "Active"
+
+## Usage
 
 **Note that this isn't finished yet and is only here for testing purposes. Currently it only works by linkng the external GoldSrc game directory and as such can't yet be included into your Godot Project Directory**
 
 ![](https://i.imgur.com/FINHIjn.png)
 
-Drag the BSP_Map.tscn file from the addons/gldsrcBSP folder into the scene tree.  
-  
-Enter thet path to the bsp in "Path" field and Press "Create Map"  
-  
-If you want the map to generate on runtime don't press "Create Map" and it will automatically be created on launch.  
-    
+Drag the BSP_Map.tscn file from the addons/gldsrcBSP folder into the scene tree.
+
+Enter thet path to the bsp in "Path" field and Press "Create Map"
+
+If you want the map to generate on runtime don't press "Create Map" and it will automatically be created on launch.
+
 ## Entities
-  
-This plugin supports various but not all entities.  
-If you want a body to trigger/interact with the entities add it to the "hlTrigger" group.  
 
+This plugin supports various but not all entities.
+If you want a body to trigger/interact with the entities add it to the "hlTrigger" group.
 
-## Lightmaps  
+## Lightmaps
 
 You can import lightmaps from the BSP file but you will need to set your enviroment to "Clear Color" and up the ambient light.
 
@@ -49,7 +48,14 @@ manually to act as shadow casters.
 For global illumination, GIProbe can be used as the resulting MeshInstances are set to be used in baked light.
 However, BakedLightmap will not work correctly as UV2 isn't generated properly for the generated meshes.
 
-## Media 
+## Material appearance
 
-![](https://i.imgur.com/STAOPjS.jpg)  
+By default, Metallic Specular is set to 0.0 on generated materials to make reflections from the sky
+much less visible. This is good for retro-looking games, but the physically correct setting is 0.5
+(which is also the default in SpatialMaterial). If you wish to have a more realistic appearance,
+adjust the Materials Metallic Specular property in the BSP_Map scene in the inspector.
+
+## Media
+
+![](https://i.imgur.com/STAOPjS.jpg)
 ![](https://i.imgur.com/UtKyFi5.png)

--- a/addons/gldsrcBSP/src/BSP_Map.gd
+++ b/addons/gldsrcBSP/src/BSP_Map.gd
@@ -48,6 +48,9 @@ export var enableEntities = true
 export var disableSound = false
 export var textureLights = false
 
+# Defaults to 0.0 for a more "retro" appearance with fewer reflections from the environment.
+export(float, 0.0, 1.0, 0.01) var materialsMetallicSpecular = 0.0
+
 var simpleCombine =  true
 var physicsPropsDontRotate = true
 var playerSpawn = {"position":Vector3.ZERO,"rotation":Vector3.ZERO}

--- a/addons/gldsrcBSP/src/levelBuilder.gd
+++ b/addons/gldsrcBSP/src/levelBuilder.gd
@@ -360,6 +360,8 @@ func createMat(texture,textureName,render = null):
 			
 		mat.flags_world_triplanar = true
 		mat.emission_enabled = true
+		# Allow metallic specular control to avoid issues with the environment being too reflective.
+		mat.metallic_specular = get_parent().materialsMetallicSpecular
 		#mat.emission_texture = 
 		#mat.uv1_triplanar = true
 		get_parent().saveToMaterialCache(matCacheName,mat)


### PR DESCRIPTION
A value of 0.0 generally suits retro-looking games better, as it prevents most environment reflections from being visible on the materials.

## Preview

*No GIProbe is used, but some orange-ish ambient light is added on both screenshots. Sky Contribution is set to 0 as well.*

| 0.5 (old hardcoded value) | 0.0 (new default) |
|-|-|
| ![2021-09-22_20 21 58](https://user-images.githubusercontent.com/180032/134400921-1499438b-6da6-4239-8fcc-c3f1b07a17e5.png) | ![2021-09-22_20 23 16](https://user-images.githubusercontent.com/180032/134400923-5b10fe6a-11ff-4827-871e-8157903664cf.png) |