### PR TITLE
Use nearest-neighbor filtering by default

### DIFF
--- a/addons/gldsrcBSP/BSP_Map.tscn
+++ b/addons/gldsrcBSP/BSP_Map.tscn
@@ -16,7 +16,6 @@ __meta__ = {
 "done": true
 }
 scaleFactor = 1.0
-textureFiltering = true
 
 [node name="levelBuilder" type="Spatial" parent="."]
 script = ExtResource( 3 )


### PR DESCRIPTION
When using the instanced scene, texture filtering was enabled, unlike the default value in the script.

Nearest-neighbor filtering looks better for pixel art. Given the low texture density on today's displays (1080p and more), GoldSrc map textures generally look better with nearest-neighbor filtering than linear filtering.

This behavior is not consistent with GoldSrc games in OpenGL mode, but it is consistent with GoldSrc games in software mode. Moreover, Valve themselves used nearest-neighbor filtering when porting Counter-Strike 1.6's de_dust2 to CS:GO for the game's 20th anniversary:

![image](https://user-images.githubusercontent.com/180032/134414108-30f2ea88-f339-45d3-8b15-5fa270aab376.png)